### PR TITLE
Remove lifecycle scripts from package.json

### DIFF
--- a/packages/nuka/package.json
+++ b/packages/nuka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuka-carousel",
-  "version": "5.2.0",
+  "version": "v5.2.0-wanderlog.2",
   "description": "Pure React Carousel",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -26,8 +26,6 @@
     "test:e2e": "cypress open",
     "test:e2e:ci": "cypress run",
     "package": "pnpm pack",
-    "prepublishOnly": "shx cp ../../README.md ./README.md && shx cp ../../LICENSE ./LICENSE && pnpm run build",
-    "postpack": "shx rm ./README.md && shx rm ./LICENSE",
     "storybook": "start-storybook -p 6006",
     "storybook:build": "build-storybook",
     "chromatic": "chromatic --exit-zero-on-changes"


### PR DESCRIPTION
# Motivation
- This repo is fork of `nuka-carousel` which doesn't get published. By leaving the lifecycle scripts in the package.json, we cause Yarn to error while it creates a cache file for this package, since it's not able to find the necessary `shx` command, nor the files referenced in those scripts

# Changes
- Remove lifecycle scripts from package.json

# Testing
Successfully ran `yarn install` when it was previously failing.