### PR TITLE
feat: support RTL direction in Carousel and SliderList

### DIFF
--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -21,7 +21,8 @@ import {
   addEvent,
   removeEvent,
   getNextMoveIndex,
-  getPrevMoveIndex
+  getPrevMoveIndex,
+  rtlMultiplier
 } from './utils';
 import { useFrameHeight } from './hooks/use-frame-height';
 
@@ -416,13 +417,12 @@ export const Carousel = React.forwardRef<CarouselRef, CarouselProps>(
           return;
         }
 
-        const isRTL = typeof document !== 'undefined' && document.dir === 'rtl';
-        const shouldGoNext = isRTL ? move < 0 : move > 0;
+        const adjustedMove = rtlMultiplier() * move;
 
-        if (shouldGoNext) {
-          nextSlide();
-        } else {
+        if (adjustedMove > 0) {
           prevSlide();
+        } else {
+          nextSlide();
         }
 
         setMove(0);

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -416,7 +416,10 @@ export const Carousel = React.forwardRef<CarouselRef, CarouselProps>(
           return;
         }
 
-        if (move > 0) {
+        const isRTL = typeof document !== 'undefined' && document.dir === 'rtl';
+        const shouldGoNext = isRTL ? move < 0 : move > 0;
+
+        if (shouldGoNext) {
           nextSlide();
         } else {
           prevSlide();

--- a/packages/nuka/src/slider-list.ts
+++ b/packages/nuka/src/slider-list.ts
@@ -66,6 +66,8 @@ const getPositioning = (
   wrapAround?: boolean,
   move?: number
 ): string | undefined => {
+  const isRTL = typeof document !== 'undefined' && document.dir === 'rtl';
+
   // When wrapAround is enabled, we show the slides 3 times
   const totalCount = wrapAround ? 3 * count : count;
   const slideSize = 100 / totalCount;
@@ -83,13 +85,17 @@ const getPositioning = (
     initialValue += slideSize * excessLeftSlides;
   }
 
-  const horizontalMove = getTransition(
+  let horizontalMove = getTransition(
     count,
     initialValue,
     currentSlide,
     cellAlign,
     wrapAround
   );
+
+  if (isRTL) {
+    horizontalMove = -horizontalMove;
+  }
 
   // Special-case this. It's better to return undefined rather than a
   // transform of 0 pixels since transforms can cause flickering in chrome.

--- a/packages/nuka/src/slider-list.ts
+++ b/packages/nuka/src/slider-list.ts
@@ -1,5 +1,6 @@
 import React, { CSSProperties, ReactNode } from 'react';
 import { Alignment } from './types';
+import { rtlMultiplier } from './utils';
 
 const getSliderListWidth = (
   count: number,
@@ -66,8 +67,6 @@ const getPositioning = (
   wrapAround?: boolean,
   move?: number
 ): string | undefined => {
-  const isRTL = typeof document !== 'undefined' && document.dir === 'rtl';
-
   // When wrapAround is enabled, we show the slides 3 times
   const totalCount = wrapAround ? 3 * count : count;
   const slideSize = 100 / totalCount;
@@ -85,17 +84,9 @@ const getPositioning = (
     initialValue += slideSize * excessLeftSlides;
   }
 
-  let horizontalMove = getTransition(
-    count,
-    initialValue,
-    currentSlide,
-    cellAlign,
-    wrapAround
-  );
-
-  if (isRTL) {
-    horizontalMove = -horizontalMove;
-  }
+  const horizontalMove =
+    rtlMultiplier() *
+    getTransition(count, initialValue, currentSlide, cellAlign, wrapAround);
 
   // Special-case this. It's better to return undefined rather than a
   // transform of 0 pixels since transforms can cause flickering in chrome.

--- a/packages/nuka/src/utils.ts
+++ b/packages/nuka/src/utils.ts
@@ -85,3 +85,14 @@ export const getPrevMoveIndex = (
 
   return currentSlide - slidesToScroll;
 };
+
+/**
+ * Returns a multiplier for adjusting carousel behavior based on layout direction.
+ * In RTL (right-to-left) layouts, returns -1 to invert drag and translation directions.
+ * In LTR (left-to-right) layouts, returns 1 to maintain default behavior.
+ * @returns {number} -1 for RTL mode, 1 for LTR mode
+ */
+export const rtlMultiplier = (): number => {
+  const isRTL = typeof document !== 'undefined' && document.dir === 'rtl';
+  return isRTL ? -1 : 1;
+};


### PR DESCRIPTION
## Motivation

[Notion](https://www.notion.so/wanderlog/Carousel-direction-is-incorrect-for-RTL-web-2b8f9a6861f680a28da7e3bacc99bd59?source=copy_link)

The current implementation of the slider does not support RTL because the translation goes in the wrong direction and draggable moves are applied in the wrong direction.

## Changes

- Add RTL detection in `carousel.tsx` by checking `document.dir === 'rtl'`
- Reverse drag direction logic in `carousel.tsx`:
  - When RTL is detected, negative drag moves trigger next slide (instead of previous)
  - When RTL is detected, positive drag moves trigger previous slide (instead of next)
- Add RTL detection in `slider-list.ts` by checking `document.dir === 'rtl'`
- Invert horizontal translation in `slider-list.ts` when RTL is detected to make slides move in the correct direction

## Testing

- Manually test the carousel in an RTL context by setting `document.dir = 'rtl'`
- Verify that dragging left advances to the next slide in RTL mode
- Verify that dragging right goes to the previous slide in RTL mode
- Verify that slide transitions animate in the correct direction for RTL layouts

### Before

https://github.com/user-attachments/assets/e81cea59-90e6-4815-9408-790e6dc32313

### After

https://github.com/user-attachments/assets/6c7f09f9-545e-4ca7-9f7f-8be94e3283d1
